### PR TITLE
Update base

### DIFF
--- a/adt-pulse-mqtt/Dockerfile
+++ b/adt-pulse-mqtt/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=homeassistant/amd64-base:latest
 FROM $BUILD_FROM
 
 ENV LANG C.UTF-8

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
 
 cd adt-pulse-mqtt
-docker build --build-arg BUILD_FROM="homeassistant/amd64-base:latest" -t local/adt-pulse-mqtt .
+
+# Default build is based on homeassistant/amd64-base:latest
+docker build -t local/adt-pulse-mqtt .
+
+# To specify a different platform, set build-arg to a different base image:
+# homeassistant/armhf-base
+# homeassistant/amd64-base
+# homeassistant/aarch64-base
+# homeassistant/i386-base
+
+#docker build --build-arg BUILD_FROM="homeassistant/amd64-base:latest" -t local/adt-pulse-mqtt .
+
+


### PR DESCRIPTION
* Update README.md

* Revert "Update README.md"

This reverts commit d07f80ed6a0ada3d142e5e75385668ba62844b21.

* Use MQTT URL instead of host in options

- Replace mqtt client host with client URL to allow more MQTT broker options outside of hass.io environment
- Docker local container build script for use outside of Hassio environment (e.g. Docker host)

* Optional mqtt_url option

Use mqtt_url option if set, otherwise build URL from mqtt_host option.

* Base image default

Set base image to default in Docker file and add comments in docker-build.sh on how to build a local image from a different base image.